### PR TITLE
Add -O2 to the ghc build options

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -57,5 +57,5 @@ library
                                 Rank2Types,
                                 MagicHash
 
-        ghc-options:            -Wall -funbox-strict-fields
+        ghc-options:            -Wall -O2 -funbox-strict-fields
         ghc-prof-options:       -prof -auto-all


### PR DESCRIPTION
I just saw the cabal file doesn't include -O2 in the options passed to GHC when building the library. Is there any reason for this? 

There are some key optimizations that are performed only with -O2 AFAIK, and they can make a difference on cereal's code maybe? 

I seem to gain consistently a few dozens of microsecs on the benchmarks, in particular it becomes significantly faster than 'binary' (which is built with -O2) on the last two benchmarks.
