### PR TITLE
Unbreak cereal for clang

### DIFF
--- a/src/Data/Serialize.hs
+++ b/src/Data/Serialize.hs
@@ -7,8 +7,7 @@
            , TypeOperators
            , BangPatterns
            , KindSignatures
-           , ScopedTypeVariables
-  #-}
+           , ScopedTypeVariables #-}
 #endif
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
http://ghc.haskell.org/trac/ghc/ticket/7678 tracks a similar bug with clang. The error message is:

```
Preprocessing library cereal-0.3.5.2...
src/Data/Serialize.hs:11:4:
     error: invalid preprocessing directive
      #-}
       ^
```
