### PR TITLE
Added function to conveniently check for presence of fixed values.

### DIFF
--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -34,6 +34,7 @@ module Data.Serialize.Get (
 
     -- * Parsing
     , ensure
+    , expect
     , isolate
     , label
     , skip
@@ -317,6 +318,11 @@ ensureRec n = Get $ \s0 b0 m0 kf ks ->
     if B.length s0 >= n
     then ks s0 b0 m0 s0
     else unGet (demandInput >> ensureRec n) s0 b0 m0 kf ks
+
+-- | Perform an action, failing if the read result does not match the argument
+--   provided.
+expect :: (Eq a, Serialize a) => a -> Get a
+expect x = get >>= \y -> if x == y then return x else empty
 
 -- | Isolate an action to operating within a fixed block of bytes.  The action
 --   is required to consume all the bytes that it is isolated to.


### PR DESCRIPTION
Many binary formats have sentinel values/delimiters and binary currently does not provide a convenient way to check for these. Added a simple function that compares the parsed value with an expected value.
