### PR TITLE
Use an explicit import list for GHC.Base

### DIFF
--- a/src/Data/Serialize/Builder.hs
+++ b/src/Data/Serialize/Builder.hs
@@ -67,7 +67,7 @@ import qualified Data.ByteString.Lazy     as L
 import qualified Data.ByteString.Internal as S
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
-import GHC.Base
+import GHC.Base (Int(..), uncheckedShiftRL#)
 import GHC.Word (Word32(..),Word16(..),Word64(..))
 
 #if WORD_SIZE_IN_BITS < 64 && __GLASGOW_HASKELL__ >= 608


### PR DESCRIPTION
cereal does not build with current GHC HEAD due to reorganization of the GHC.\* modules. In general importing those modules without an explicit import list runs the risk of breakage when those modules export new names, which may happen for any reason.

I tested that this builds with 7.6.3, 7.8.3, and HEAD from yesterday.
