### PR TITLE
Exclude GHC < 7.2 due to usage of unsafeDupablePerformIO

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -28,7 +28,7 @@ library
         default-language:       Haskell2010
 
         build-depends:          bytestring >= 0.10.0.0,
-                                base == 4.*, containers, array,
+                                base >= 4.4 && < 5, containers, array,
                                 ghc-prim >= 0.2
 
         hs-source-dirs:         src


### PR DESCRIPTION
```
src/Data/Serialize/Get.hs:112:26:
    Module `System.IO.Unsafe' does not export `unsafeDupablePerformIO'
```

Only applies to cereal-0.5, [revision here](https://hackage.haskell.org/package/cereal-0.5.0.0/revisions/)
