### PR TITLE
Use `Builder` provided functions to serialize `Double`/`Float`

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -28,7 +28,7 @@ source-repository head
 library
         default-language:       Haskell2010
 
-        build-depends:          bytestring >= 0.10.0.0,
+        build-depends:          bytestring >= 0.10.2.0,
                                 base >= 4.4 && < 5, containers, array,
                                 ghc-prim >= 0.2
 

--- a/src/Data/Serialize/IEEE754.hs
+++ b/src/Data/Serialize/IEEE754.hs
@@ -35,6 +35,7 @@ import Data.Array.ST ( newArray, readArray, MArray, STUArray )
 import Data.Word ( Word32, Word64 )
 import Data.Serialize.Get
 import Data.Serialize.Put
+import qualified Data.ByteString.Builder as Builder
 
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative ( (<$>) )
@@ -64,35 +65,27 @@ getFloat64be = wordToDouble <$> getWord64be
 
 -- | Write a Float in little endian IEEE-754 format
 putFloat32le :: Float -> Put
-putFloat32le = putWord32le . floatToWord
+putFloat32le = putBuilder . Builder.floatLE
 
 -- | Write a Float in big endian IEEE-754 format
 putFloat32be :: Float -> Put
-putFloat32be = putWord32be . floatToWord
+putFloat32be = putBuilder . Builder.floatBE
 
 -- | Write a Double in little endian IEEE-754 format
 putFloat64le :: Double -> Put
-putFloat64le = putWord64le . doubleToWord
+putFloat64le = putBuilder . Builder.doubleLE
 
 -- | Write a Double in big endian IEEE-754 format
 putFloat64be :: Double -> Put
-putFloat64be = putWord64be . doubleToWord
+putFloat64be = putBuilder . Builder.doubleBE
 
 {-# INLINE wordToFloat #-}
 wordToFloat :: Word32 -> Float
 wordToFloat x = runST (cast x)
 
-{-# INLINE floatToWord #-}
-floatToWord :: Float -> Word32
-floatToWord x = runST (cast x)
-
 {-# INLINE wordToDouble #-}
 wordToDouble :: Word64 -> Double
 wordToDouble x = runST (cast x)
-
-{-# INLINE doubleToWord #-}
-doubleToWord :: Double -> Word64
-doubleToWord x = runST (cast x)
 
 {-# INLINE cast #-}
 cast :: (MArray (STUArray s) a (ST s),

--- a/src/Data/Serialize/IEEE754.hs
+++ b/src/Data/Serialize/IEEE754.hs
@@ -30,7 +30,7 @@ import Data.Word ( Word32, Word64 )
 import Data.Serialize.Get
 import Data.Serialize.Put
 import qualified Data.ByteString.Builder as Builder
-import System.IO.Unsafe (unsafePerformIO)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 import Foreign.Marshal.Alloc (alloca)
 import Foreign.Storable (peek, poke)
 import Foreign.Ptr (castPtr, Ptr)
@@ -71,14 +71,12 @@ putFloat64le = putBuilder . Builder.doubleLE
 putFloat64be :: Double -> Put
 putFloat64be = putBuilder . Builder.doubleBE
 
-{-# NOINLINE wordToFloat #-}
 wordToFloat :: Word32 -> Float
-wordToFloat w = unsafePerformIO $ alloca $ \(ptr :: Ptr Word32) -> do
+wordToFloat w = unsafeDupablePerformIO $ alloca $ \(ptr :: Ptr Word32) -> do
     poke ptr w
     peek (castPtr ptr)
 
-{-# NOINLINE wordToDouble #-}
 wordToDouble :: Word64 -> Double
-wordToDouble w = unsafePerformIO $ alloca $ \(ptr :: Ptr Word64) -> do
+wordToDouble w = unsafeDupablePerformIO $ alloca $ \(ptr :: Ptr Word64) -> do
     poke ptr w
     peek (castPtr ptr)

--- a/src/Data/Serialize/IEEE754.hs
+++ b/src/Data/Serialize/IEEE754.hs
@@ -1,12 +1,9 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 #ifndef MIN_VERSION_base
 #define MIN_VERSION_base(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_array
-#define MIN_VERSION_array(x,y,z) 1
 #endif
 
 -- | IEEE-754 parsing, as described in this stack-overflow article:
@@ -29,22 +26,17 @@ module Data.Serialize.IEEE754 (
 
 ) where
 
-import Control.Monad.ST ( runST, ST )
-
-import Data.Array.ST ( newArray, readArray, MArray, STUArray )
 import Data.Word ( Word32, Word64 )
 import Data.Serialize.Get
 import Data.Serialize.Put
 import qualified Data.ByteString.Builder as Builder
+import System.IO.Unsafe (unsafePerformIO)
+import Foreign.Marshal.Alloc (alloca)
+import Foreign.Storable (peek, poke)
+import Foreign.Ptr (castPtr, Ptr)
 
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative ( (<$>) )
-#endif
-
-#if MIN_VERSION_array(0,4,0)
-import Data.Array.Unsafe (castSTUArray)
-#else
-import Data.Array.ST (castSTUArray)
 #endif
 
 -- | Read a Float in little endian IEEE-754 format
@@ -79,16 +71,14 @@ putFloat64le = putBuilder . Builder.doubleLE
 putFloat64be :: Double -> Put
 putFloat64be = putBuilder . Builder.doubleBE
 
-{-# INLINE wordToFloat #-}
+{-# NOINLINE wordToFloat #-}
 wordToFloat :: Word32 -> Float
-wordToFloat x = runST (cast x)
+wordToFloat w = unsafePerformIO $ alloca $ \(ptr :: Ptr Word32) -> do
+    poke ptr w
+    peek (castPtr ptr)
 
-{-# INLINE wordToDouble #-}
+{-# NOINLINE wordToDouble #-}
 wordToDouble :: Word64 -> Double
-wordToDouble x = runST (cast x)
-
-{-# INLINE cast #-}
-cast :: (MArray (STUArray s) a (ST s),
-         MArray (STUArray s) b (ST s)) =>
-        a -> ST s b
-cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0
+wordToDouble w = unsafePerformIO $ alloca $ \(ptr :: Ptr Word64) -> do
+    poke ptr w
+    peek (castPtr ptr)

--- a/src/Data/Serialize/IEEE754.hs
+++ b/src/Data/Serialize/IEEE754.hs
@@ -71,11 +71,13 @@ putFloat64le = putBuilder . Builder.doubleLE
 putFloat64be :: Double -> Put
 putFloat64be = putBuilder . Builder.doubleBE
 
+{-# INLINE wordToFloat #-}
 wordToFloat :: Word32 -> Float
 wordToFloat w = unsafeDupablePerformIO $ alloca $ \(ptr :: Ptr Word32) -> do
     poke ptr w
     peek (castPtr ptr)
 
+{-# INLINE wordToDouble #-}
 wordToDouble :: Word64 -> Double
 wordToDouble w = unsafeDupablePerformIO $ alloca $ \(ptr :: Ptr Word64) -> do
     poke ptr w


### PR DESCRIPTION
The old functions make the productivity go down to 30% when serializing
large amounts of `Double`/`Float`s. I'm guessing it's because the large
amounts of short-lived arrays they create.

We have some cases where this change gives a 100% speedup. Ideally we'd remove `cast` entirely, also from deserialization.