### PR TITLE
Constant-memory IArray packing

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -48,7 +48,8 @@ test-suite test-cereal
 
         type:                   exitcode-stdio-1.0
 
-        build-depends:          base == 4.*,
+        build-depends:          array,
+                                base == 4.*,
                                 bytestring,
                                 QuickCheck,
                                 test-framework,

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -104,7 +104,7 @@ module Data.Serialize.Get (
 import qualified Control.Applicative as A
 import qualified Control.Monad as M
 import Control.Monad (unless)
-import Data.Array.IArray (IArray,listArray)
+import Data.Array.IArray (IArray, listArray, range)
 import Data.Ix (Ix)
 import Data.List (intercalate)
 import Data.Maybe (isNothing,fromMaybe)
@@ -763,12 +763,13 @@ getListOf m = go [] =<< getWord64be
 -- | Get an IArray in the following format:
 --   index (lower bound)
 --   index (upper bound)
---   Word64 (big endian format)
 --   element 1
 --   ...
 --   element n
 getIArrayOf :: (Ix i, IArray a e) => Get i -> Get e -> Get (a i e)
-getIArrayOf ix e = M.liftM2 listArray (getTwoOf ix ix) (getListOf e)
+getIArrayOf ix e = do
+  bounds <- getTwoOf ix ix
+  listArray bounds <$> M.mapM (const e) (range bounds)
 
 -- | Get a sequence in the following format:
 --   Word64 (big endian format)

--- a/src/Data/Serialize/Put.hs
+++ b/src/Data/Serialize/Put.hs
@@ -313,7 +313,7 @@ putListOf pa = \l -> do
 putIArrayOf :: (Ix i, IArray a e) => Putter i -> Putter e -> Putter (a i e)
 putIArrayOf pix pe a = do
   putTwoOf pix pix (bounds a)
-  putListOf pe (elems a)
+  mapM_ (pe . (a !)) (range $ bounds a)
 {-# INLINE putIArrayOf #-}
 
 putSeqOf :: Putter a -> Putter (Seq.Seq a)

--- a/tests/RoundTrip.hs
+++ b/tests/RoundTrip.hs
@@ -12,6 +12,7 @@
 --
 module RoundTrip where
 
+import Data.Array.Unboxed
 import Data.Serialize
 import Data.Serialize.Get
 import Data.Serialize.Put
@@ -55,6 +56,9 @@ tests  = testGroup "Round Trip"
     $ roundTrip (putTwoOf putWord8 putWord8) (getTwoOf getWord8 getWord8)
   , testProperty "[Word8] Round Trip"
     $ roundTrip (putListOf putWord8) (getListOf getWord8)
+  , testProperty "UArray Int Word8" $ \list ->
+    roundTrip (putIArrayOf put putWord8 :: Putter (UArray Int Word8))
+              (getIArrayOf get getWord8) (listArray (0,length list) list)
   , testProperty "Maybe Word8 Round Trip"
     $ roundTrip (putMaybeOf putWord8) (getMaybeOf getWord8)
   , testProperty "Either Word8 Word16be Round Trip "


### PR DESCRIPTION
Currently, the `IArray` serializer delegates to `elems` and the list serializer. Unfortunately, this results in a second full copy of the array, as the list serializer needs to walk the list (holding the head) to find its length. This is necessary for arbitrary lists, but not for arrays where we know the dimensions beforehand.

This change does away with the extra length field; it outputs the bounds and then spits elements one by one, in array (`Ix`) order. The parser was similarly changed. In the meantime, I also added a small round-trip test for the array serialization functionality.

As I was writing this, I just realized that this is a breaking change to the IArray serialization format, as it removes the superfluous `Word64` length. If backwards compatibility is desired, we could calculate and add that field back in so the format is identical.

Here is the test script I used to verify the before/after memory behavior:

```haskell
module Main where

import Data.Array.Unboxed
import Data.ByteString.Builder
import Data.Serialize
import System.IO

wholeLottaNothing :: UArray Int Int
wholeLottaNothing = listArray (0,10000000) (repeat 0)

main :: IO ()
main = withFile "/dev/null" AppendMode $ \sink ->
  hPutBuilder sink . execPut $ put wholeLottaNothing
```