### PR TITLE
Add bytesRead to Data.Serialize.Get

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -1,5 +1,5 @@
 name:                   cereal
-version:                0.5.3.0
+version:                0.5.4.0
 license:                BSD3
 license-file:           LICENSE
 author:                 Lennart Kolmodin <kolmodin@dtek.chalmers.se>,

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -267,7 +267,7 @@ get  = Get (\s0 b0 m0 w _ k -> k s0 b0 m0 w s0)
 {-# INLINE get #-}
 
 put :: B.ByteString -> Int -> Get ()
-put s w = Get (\_ b0 m _ _ k -> k s b0 m w ())
+put s !w = Get (\_ b0 m _ _ k -> k s b0 m w ())
 {-# INLINE put #-}
 
 label :: String -> Get a -> Get a


### PR DESCRIPTION
After another 2 years https://github.com/GaloisInc/cereal/issues/8 gets a PR.

I added the current byte count to the state of Get.
Running the benchmark locally, I can't see a major performance hit (only ran each version once though).

I'm a bit unsure about the `MonadPlus` instance and how to add tests. Can you please have a look at those?

Also https://github.com/GaloisInc/cereal/issues/8 also mentions the idea of a bytesWritten. Looking at the current `Data.Serialize.Put` I don't think it is possible. Was the rewrite already done? Are there plans to go to something similar to `Data.Serialize.Get`?
