### PR TITLE
Allow building with older bytestrings via bytestring-builder

### DIFF
--- a/cereal.cabal
+++ b/cereal.cabal
@@ -25,15 +25,28 @@ source-repository head
   type:     git
   location: git://github.com/GaloisInc/cereal.git
 
+flag bytestring-builder
+  description:
+    Decides whether to use an older version of bytestring along with bytestring-builder or just a newer version of bytestring.
+    .
+    This flag normally toggles automatically but you can use `-fbytestring-builder` or `-f-bytestring-builder` to explicitly change it.
+  default: False
+  manual: False
+
 library
         default-language:       Haskell2010
 
-        build-depends:          bytestring >= 0.10.2.0,
-                                base >= 4.4 && < 5, containers, array,
+        build-depends:          base >= 4.4 && < 5, containers, array,
                                 ghc-prim >= 0.2
 
         if !impl(ghc >= 8.0)
           build-depends:        fail == 4.9.*
+
+        if flag(bytestring-builder)
+          build-depends:        bytestring >= 0.9    && < 0.10.4,
+                                bytestring-builder >= 0.10.4 && < 1
+        else
+          build-depends:        bytestring >= 0.10.4 && < 1
 
         hs-source-dirs:         src
 
@@ -52,7 +65,7 @@ test-suite test-cereal
         type:                   exitcode-stdio-1.0
 
         build-depends:          base == 4.*,
-                                bytestring >= 0.10.8.1,
+                                bytestring >= 0.9,
                                 QuickCheck,
                                 test-framework,
                                 test-framework-quickcheck2,

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -59,10 +59,7 @@ module Data.Serialize.Get (
     -- ** ByteStrings
     , getByteString
     , getLazyByteString
-
-#if MIN_VERSION_bytestring(0,10,4)
     , getShortByteString
-#endif
 
     -- ** Big-endian reads
     , getWord16be
@@ -116,18 +113,13 @@ import qualified Data.ByteString          as B
 import qualified Data.ByteString.Internal as B
 import qualified Data.ByteString.Unsafe   as B
 import qualified Data.ByteString.Lazy     as L
+import qualified Data.ByteString.Short    as BS
 import qualified Data.IntMap              as IntMap
 import qualified Data.IntSet              as IntSet
 import qualified Data.Map                 as Map
 import qualified Data.Sequence            as Seq
 import qualified Data.Set                 as Set
 import qualified Data.Tree                as T
-
-
-#if MIN_VERSION_bytestring(0,10,4)
-import qualified Data.ByteString.Short as BS
-#endif
-
 
 #if defined(__GLASGOW_HASKELL__) && !defined(__HADDOCK__)
 import GHC.Base
@@ -511,12 +503,10 @@ getLazyByteString :: Int64 -> Get L.ByteString
 getLazyByteString n = f `fmap` getByteString (fromIntegral n)
   where f bs = L.fromChunks [bs]
 
-#if MIN_VERSION_bytestring(0,10,4)
 getShortByteString :: Int -> Get BS.ShortByteString
 getShortByteString n = do
   bs <- getBytes n
   return $! BS.toShort bs
-#endif
 
 
 ------------------------------------------------------------------------

--- a/src/Data/Serialize/Put.hs
+++ b/src/Data/Serialize/Put.hs
@@ -457,8 +457,7 @@ lazyToStrictByteString = packChunks
 
 -- | Pack the chunks of a lazy bytestring into a single strict bytestring.
 packChunks :: L.ByteString -> S.ByteString
-packChunks lbs = do
-    S.unsafeCreate (fromIntegral $ L.length lbs) (copyChunks lbs)
+packChunks lbs = S.unsafeCreate (fromIntegral $ L.length lbs) (copyChunks lbs)
   where
     copyChunks !L.Empty                         !_pf = return ()
     copyChunks !(L.Chunk (S.PS fpbuf o l) lbs') !pf  = do


### PR DESCRIPTION
Currently, `cereal` requires `bytestring-0.10.4` or later. Unfortunately, this causes us no end of grief when trying to install `cereal` in combination with other libraries on GHC 7.4.2 and 7.6.3, since the version of `bytestring` shipped with those GHCs goes back to `bytestring-0.9`. ([Here](https://travis-ci.org/ekmett/zippers/jobs/174006438#L236) is an example.)

Luckily, the functionality from newer `bytestring`s can be backported easily using the `bytestring-builder` package (except for one function, `toStrict`, which is easy to redefine locally). I guard whether to install the `bytestring-builder` package with a `Cabal` flag so as to not add dependencies for newer GHCs, but it would also work just as well to depend on `bytestring-builder` unconditionally.