### PR TITLE
Fix integer serialization for negative Integer's.

### DIFF
--- a/src/Data/Serialize.hs
+++ b/src/Data/Serialize.hs
@@ -254,7 +254,7 @@ instance Serialize Integer where
     put n = do
         putWord8 1
         put sign
-        let len = ((nrBits n + 7) `div` 8)
+        let len = ((nrBits (abs n) + 7) `div` 8)
         putWord64be (fromIntegral len)
         mapM_ put (unroll (abs n))         -- unroll the bytes
      where
@@ -312,7 +312,7 @@ instance Serialize Natural where
 
     put n = do
         putWord8 1
-        let len = ((nrBits n + 7) `div` 8)
+        let len = ((nrBits (abs n) + 7) `div` 8)
         putWord64be (fromIntegral len)
         mapM_ put (unroll (abs n))         -- unroll the bytes
 


### PR DESCRIPTION
@elliottt 

Sorry, not sure how this slipped (aside from the fact that I didn't make
a test framework).   Obviously nrBits only works on positives and
negatives are handled via a sign bit so we need to take the `abs`.