### PR TITLE
Fix docs which claim the number of bytes consumed is returned for run…

### DIFF
--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -300,8 +300,8 @@ runGetPartial m = runGetChunk m Nothing
 {-# INLINE runGetPartial #-}
 
 -- | Run the Get monad applies a 'get'-based parser on the input
--- ByteString, starting at the specified offset. Additional to the result of get it returns the number of
--- consumed bytes and the rest of the input.
+-- ByteString, starting at the specified offset. In addition to the result of get
+-- it returns the rest of the input.
 runGetState :: Get a -> B.ByteString -> Int
             -> Either String (a, B.ByteString)
 runGetState m str off = case runGetState' m str off of
@@ -310,8 +310,8 @@ runGetState m str off = case runGetState' m str off of
 {-# INLINE runGetState #-}
 
 -- | Run the Get monad applies a 'get'-based parser on the input
--- ByteString, starting at the specified offset. Additional to the result of get it returns the number of
--- consumed bytes and the rest of the input, even in the event of a failure.
+-- ByteString, starting at the specified offset. In addition to the result of get
+-- it returns the rest of the input, even in the event of a failure.
 runGetState' :: Get a -> B.ByteString -> Int
              -> (Either String a, B.ByteString)
 runGetState' m str off =


### PR DESCRIPTION
…GetState (likely a holdover from 'binary')

It may have come from the `Int64` return value here:
https://hackage.haskell.org/package/binary-0.5.1.1/docs/Data-Binary-Get.html