### PR TITLE
fix: Add zero and negative byte length checks to ensure

### DIFF
--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -366,7 +366,10 @@ runGetLazyState m lstr = case runGetLazy' m lstr of
 --   input, otherwise fail.
 {-# INLINE ensure #-}
 ensure :: Int -> Get B.ByteString
-ensure n0 = n0 `seq` Get $ \ s0 b0 m0 w0 kf ks -> let
+ensure n0
+  | n0 < 0 = fail "Attempted to ensure negative amount of bytes"
+  | n0 == 0 = pure mempty
+  | otherwise = n0 `seq` Get $ \ s0 b0 m0 w0 kf ks -> let
     n' = n0 - B.length s0
     in if n' <= 0
         then ks s0 b0 m0 w0 s0


### PR DESCRIPTION
## Summary

`ensure` is a publically exported function, which has some odd behaviour when given a byte length of zero or less.

It raises an error when the value is zero, but happily returns a value when the byte length is negative.

I've switched these two behaviours around.

## Current behaviour:

```
λ> runGet (ensure (-1)) "0123"
Right "0123"
λ> runGet (isolate 0 getWord8) "0123"
Left "too few bytes\nFrom:\tdemandInput\n\n"
```

## New behaviour:

```
λ> runGet (ensure (-1)) "0123"
Left "Failed reading: Attempted to ensure negative amount of bytes\nEmpty call stack\n"
λ> runGet (ensure 0) "0123"
Right ""
```