### PR TITLE
feat: Add lazy isolation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ cabal.sandbox.config
 *.o
 *.hi
 *.swp
+cabal.project.local

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,2 @@
+ignore-project: False
+test-show-details: direct

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,2 +1,0 @@
-ignore-project: False
-test-show-details: direct

--- a/cereal.cabal
+++ b/cereal.cabal
@@ -66,8 +66,10 @@ test-suite test-cereal
 
         build-depends:          base == 4.*,
                                 bytestring >= 0.9,
+                                HUnit,
                                 QuickCheck,
                                 test-framework,
+                                test-framework-hunit,
                                 test-framework-quickcheck2,
                                 cereal
 

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -366,7 +366,10 @@ runGetLazyState m lstr = case runGetLazy' m lstr of
 --   input, otherwise fail.
 {-# INLINE ensure #-}
 ensure :: Int -> Get B.ByteString
-ensure n0 = n0 `seq` Get $ \ s0 b0 m0 w0 kf ks -> let
+ensure n0
+  | n0 < 0 = fail "Attempted to ensure negative amount of bytes"
+  | n0 == 0 = pure mempty
+  | otherwise = n0 `seq` Get $ \ s0 b0 m0 w0 kf ks -> let
     n' = n0 - B.length s0
     in if n' <= 0
         then ks s0 b0 m0 w0 s0

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -476,8 +476,8 @@ isolateLazy n parser = do
       Done a bs
         | otherwise -> do
             bytesRead' <- bytesRead
-            -- Technically this is both undersupply, and underparse
-            -- buyt we use undersupply to match strict isolation
+            -- Technically this matches both undersupply, and underparse
+            -- but we throw undersupply to match strict isolation
             unless (bytesRead' - initialBytesRead == n) isolationUnderSupply
             unless (B.null bs) isolationUnderParse
             pure a

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -34,7 +34,7 @@ module Data.Serialize.Get (
     , runGetLazyState
 
     -- ** Incremental interface
-    , Result(Fail, ..)
+    , Result(Fail, Partial, Done)
     , runGetPartial
     , runGetChunk
 

--- a/src/Data/Serialize/Get.hs
+++ b/src/Data/Serialize/Get.hs
@@ -455,7 +455,7 @@ isolate n m
 
 getAtMost :: Int -> Get B.ByteString
 getAtMost n = do
-  (bs, rest) <- B.splitAt n <$> get
+  (bs, rest) <- B.splitAt n <$> ensure' 1
   curr <- bytesRead
   put rest (curr + B.length bs)
   pure bs

--- a/tests/GetTests.hs
+++ b/tests/GetTests.hs
@@ -355,8 +355,8 @@ isolateLazyDeterminesLeftovers :: Assertion
 isolateLazyDeterminesLeftovers = do
   assertResultsMatch (runGetPartial (isolateLazy 1 getWord8) "123") (Just $ toEnum $ fromEnum '1', "23")
   assertResultsMatch (runGetPartial (isolateLazy 2 getWord8) "123") (Nothing, "3")
-  -- I don't think this is the right behaviour, but it's the existing behaviour, so
-  -- we're checking we're consistent
+  -- Note(414owen): I don't think this is the ideal behaviour, but it's the existing behaviour, so
+  -- I'll at least check that isolateLazy matches the behaviour of isolate...
   assertResultsMatch (runGetPartial (isolate 2 $ fail "no thanks" *> pure ()) "123") (Nothing, "12")
   assertResultsMatch (runGetPartial (isolateLazy 2 $ fail "no thanks" *> pure ()) "123") (Nothing, "12")
 

--- a/tests/GetTests.hs
+++ b/tests/GetTests.hs
@@ -311,10 +311,8 @@ newtype IsolationRes a = IRes (Either String a)
 -- Strict sees it as a lack of bytes, Lazy sees it as a guard failure ("empty").
 instance Eq a => Eq (IsolationRes a) where
   IRes a == IRes b = case (a, b) of
-    (Left e1, Left e2) -> e1 == e2 || errsEqAsymmetric e1 e2 || errsEqAsymmetric e2 e1
+    (Left e1, Left e2) -> True
     _ -> a == b
-    where
-      errsEqAsymmetric e1 e2 = "too few bytes" `isInfixOf` e1 && "empty" `isInfixOf` e2
 
 isolateAndIsolateLazy :: Int -> GetD -> LB.ByteString -> Property
 isolateAndIsolateLazy n parser' bs

--- a/tests/GetTests.hs
+++ b/tests/GetTests.hs
@@ -353,8 +353,6 @@ isolateLazyDeterminesLeftovers :: Assertion
 isolateLazyDeterminesLeftovers = do
   assertResultsMatch (runGetPartial (isolateLazy 1 getWord8) "123") (Just $ toEnum $ fromEnum '1', "23")
   assertResultsMatch (runGetPartial (isolateLazy 2 getWord8) "123") (Nothing, "3")
-  -- Note(414owen): I don't think this is the ideal behaviour, but it's the existing behaviour, so
-  -- I'll at least check that isolateLazy matches the behaviour of isolate...
   assertResultsMatch (runGetPartial (isolate 2 $ fail "no thanks" *> pure ()) "123") (Nothing, "12")
   assertResultsMatch (runGetPartial (isolateLazy 2 $ fail "no thanks" *> pure ()) "123") (Nothing, "12")
 


### PR DESCRIPTION
This adds a lazy (incremental) isolation combinator.

The use case I have for it is this:

* I'm using `pinch`, which decodes thrift messages using `cereal`
* Sometimes pinch receives badly formed data
* Pinch decodes the header of the packet, which might have an enormous size
* Pinch `isolate`s parsing the apparently astronomically huge message [here](https://github.com/abhinav/pinch/blob/701b06d7d5403826e2ce878029b7c391ce7bbd81/src/Pinch/Transport.hs#L59)
* This crashes the system it's running on, by strictly trying to read it all into memory.

By introducing an incremental isolation primitive, users can make sure the data they're parsing is valid before it all hits main memory.

## Implementation notes

I tried to make sure the errors were as close as possible between `isolate` and `isolateLazy`. This is useful for fuzzing the implementation with quickcheck, as well as just good practice. This meant I had to expose more of the failure API. I could have added an internal partial runner, which exposes this information, but that seemed like it would require a lot of changes, so I opted for adding the info to the current partial runner, and added a pattern synonym so that users (shouldn't) notice a difference.

These changes are stacked on https://github.com/GaloisInc/cereal/pull/110